### PR TITLE
Use typography kit and add simple styles to center the text

### DIFF
--- a/src/components/Splash/Splash.jsx
+++ b/src/components/Splash/Splash.jsx
@@ -1,12 +1,15 @@
+// @flow
 import React from "react";
+
+import { Heading1, BodyText } from "../../kit/typography";
 
 import css from "./Splash.module.scss";
 
 const Splash = () => {
   return (
     <div className={css.container}>
-      <h1 className={css.date}>10.10.2020</h1>
-      <h3 className={css.honoring}>David & Helen</h3>
+      <Heading1>David & Helen</Heading1>
+      <BodyText>October 10, 2020</BodyText>
     </div>
   );
 };

--- a/src/components/Splash/Splash.module.scss
+++ b/src/components/Splash/Splash.module.scss
@@ -1,15 +1,10 @@
 @import "../../style/constants";
 
 .container {
+  align-items: center;
   background: $color-white;
-}
-
-.date {
-  color: $color-black;
-  font-family: $font-sans-serif;
-}
-
-.honoring {
-  color: $color-black;
-  font-family: $font-serif;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  justify-content: center;
 }


### PR DESCRIPTION
Use existing typography kit components for text. Vertically and horizontally center the text on the browser.

Screenshot:
<img width="1680" alt="splash" src="https://user-images.githubusercontent.com/32101487/72863189-ba383800-3c9d-11ea-8d3b-a81215d3ec9c.png">
