### PR TITLE
CTAButton

### DIFF
--- a/src/kit/BackToTop.jsx
+++ b/src/kit/BackToTop.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from "react";
 
-import CTALink from "./CTALink";
+import CTAButton from "./CTAButton";
 
 import css from "./BackToTop.module.scss";
 
@@ -15,7 +15,7 @@ const BackToTop = () => {
 
   return (
     <div className={css.container}>
-      <CTALink onClick={onClick}>Back to top</CTALink>
+      <CTAButton onClick={onClick}>Back to top</CTAButton>
     </div>
   );
 };

--- a/src/kit/CTAButton.jsx
+++ b/src/kit/CTAButton.jsx
@@ -4,23 +4,21 @@ import type { Node } from "react";
 
 import { SubTitle } from "./typography";
 
-import css from "./CTALink.module.scss";
+import css from "./CTAButton.module.scss";
 
 type Props = {
   children: Node,
   onClick: () => void
 };
 
-const CTALink = ({ children, onClick }: Props) => {
-  // TODO: This should return a <button/> or <a/>
-
+const CTAButton = ({ children, onClick }: Props) => {
   return (
     <div className={css.wrapper}>
-      <button className={css.link} onClick={onClick}>
+      <button className={css.button} onClick={onClick}>
         <SubTitle className={css.text}>{children}</SubTitle>
       </button>
     </div>
   );
 };
 
-export default CTALink;
+export default CTAButton;

--- a/src/kit/CTAButton.module.scss
+++ b/src/kit/CTAButton.module.scss
@@ -5,7 +5,8 @@
   position: relative;
 }
 
-.link {
+.button {
+  appearance: none;
   border: none;
   cursor: pointer;
   display: inline-block;


### PR DESCRIPTION
Rename CTALink to CTAButton (because it's a button) and add `appearance: none` in an attempt to reset button styles in Chrome for Android.