### PR TITLE
Reset button styles on CTAButton

### DIFF
--- a/src/kit/CTAButton.module.scss
+++ b/src/kit/CTAButton.module.scss
@@ -7,10 +7,12 @@
 
 .button {
   appearance: none;
+  background: none;
   border: none;
   cursor: pointer;
   display: inline-block;
   margin: 0;
+  outline: none;
   padding: 0;
   text-align: center;
   text-decoration: none;


### PR DESCRIPTION
The default styles keep appearing on Pixel 3a's Chrome. Hopefully this removes them...