### PR TITLE
Remove animation on first image

### DIFF
--- a/src/pages/Photos/Photos.jsx
+++ b/src/pages/Photos/Photos.jsx
@@ -17,18 +17,15 @@ import image2001 from "./assets/2001.jpg";
 import image2082 from "./assets/2082.jpg";
 import image2119 from "./assets/2119.jpg";
 
-type ImageType = {
+type LazyImageType = {
   alt: string,
-  src: string,
-  isFullWidth?: Boolean
-};
-
-type LazyImageType = ImageType & {
   /**
    * When set to `true`, will delay transition on the image to create
    * a staggered fade-in effect.
    */
-  delayTransition?: boolean
+  delayTransition?: boolean,
+  isFullWidth?: boolean,
+  src: string
 };
 
 const LazyImage = ({
@@ -59,20 +56,10 @@ const LazyImage = ({
   );
 };
 
-const Image = ({ alt, isFullWidth, src }: ImageType) => {
-  const classes = isFullWidth ? css.fullWidth : css.halfWidth;
-
-  return (
-    <div className={classes}>
-      <img alt={alt} src={src} />
-    </div>
-  );
-};
-
 const Photos = () => {
   return (
     <div className={css.container}>
-      <Image
+      <LazyImage
         alt="Staring off into the distance while sitting on the curb."
         isFullWidth={true}
         src={image2119}

--- a/src/pages/Photos/Photos.module.scss
+++ b/src/pages/Photos/Photos.module.scss
@@ -31,38 +31,21 @@
   visibility: visible;
 }
 
-/**
- * This is solely for the first image on the page. We need it to
- * scroll-fade in without relying on JavaScript changes.
- */
-@keyframes fadein {
-  from {
-    opacity: 0;
-    transform: translateY(20vh);
-    visibility: hidden;
-  }
-
-  to {
-    opacity: 1;
-    visibility: visible;
-  }
-}
-
 .fullWidth {
   height: auto;
   /**
    * Need `min-height` in order to get lazy loading to work.
    * This prevents the image from starting with a height of 0 pixels.
    */
-  min-height: 248px;
+  min-height: 596px;
   width: 100%;
 
-  &:nth-of-type(1) {
-    animation: fadein 1s;
+  @media screen and (max-width: $breakpoint-desktop) {
+    min-height: 446px;
+  }
 
-    @media screen and (max-width: $breakpoint-mobile) {
-      animation: none;
-    }
+  @media screen and (max-width: $breakpoint-tablet) {
+    min-height: 248px;
   }
 
   @media screen and (max-width: $breakpoint-mobile) {
@@ -77,6 +60,10 @@
    */
   min-height: 574px;
   width: 50%;
+
+  @media screen and (max-width: $breakpoint-tablet) {
+    min-height: 318px;
+  }
 
   @media screen and (max-width: $breakpoint-mobile) {
     min-height: 478px;


### PR DESCRIPTION
Because if we use `LazyImage`, the first image will load first anyway (since it's in view).