### PR TITLE
Style: reset and restyle radio buttons with placeholder colors

### DIFF
--- a/src/pages/Repondez/GuestForm.jsx
+++ b/src/pages/Repondez/GuestForm.jsx
@@ -44,24 +44,26 @@ const GuestForm = ({
           <div className={css.radioInputWrapper}>
             <input
               checked={rsvpInput === "yes"}
+              id="rsvpYes"
               name="rsvpYes"
               onChange={onRsvpChange}
               type="radio"
               value="yes"
             />
-            <label>
+            <label htmlFor="rsvpYes">
               <BodyText>Yes</BodyText>
             </label>
           </div>
           <div className={css.radioInputWrapper}>
             <input
               checked={rsvpInput === "no"}
+              id="rsvpNo"
               name="rsvpNo"
               onChange={onRsvpChange}
               type="radio"
               value="no"
             />
-            <label>
+            <label htmlFor="rsvpNo">
               <BodyText>No</BodyText>
             </label>
           </div>
@@ -75,24 +77,26 @@ const GuestForm = ({
             <div className={css.radioInputWrapper}>
               <input
                 checked={plusOneStatus === "yes"}
+                id="plusOneYes"
                 name="plusOneYes"
                 onChange={onPlusOneChange}
                 type="radio"
                 value="yes"
               />
-              <label>
+              <label htmlFor="plusOneYes">
                 <BodyText>Yes</BodyText>
               </label>
             </div>
             <div className={css.radioInputWrapper}>
               <input
                 checked={plusOneStatus === "no"}
+                id="plusOneNo"
                 name="plusOneNo"
                 onChange={onPlusOneChange}
                 type="radio"
                 value="no"
               />
-              <label>
+              <label htmlFor="plusOneNo">
                 <BodyText>No</BodyText>
               </label>
             </div>

--- a/src/style/radio.scss
+++ b/src/style/radio.scss
@@ -1,0 +1,106 @@
+/**
+ * This resets and restyles the radio button.
+ * Credit to: https://css-tricks.com/custom-styling-form-inputs-with-modern-css-features/
+ */
+
+/* stylelint-disable */
+@supports (-webkit-appearance: none) or (-moz-appearance: none) {
+  input[type="radio"] {
+    --active: #275efe;
+    --active-inner: #fff;
+    --focus: 2px rgba(39, 94, 254, 0.3);
+    --border: #bbc1e1;
+    --border-hover: #275efe;
+    --background: #fff;
+    --disabled: #f6f8ff;
+    --disabled-inner: #e1e6f9;
+
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    border: 1px solid var(--bc, var(--border));
+    background: var(--b, var(--background));
+    cursor: pointer;
+    display: inline-block;
+    height: 21px;
+    margin: 0;
+    position: relative;
+    outline: none;
+    vertical-align: top;
+    transition: background 0.3s, border-color 0.3s, box-shadow 0.2s;
+
+    &:after {
+      content: "";
+      display: block;
+      left: 0;
+      top: 0;
+      position: absolute;
+      transition: transform var(--d-t, 0.3s) var(--d-t-e, ease),
+        opacity var(--d-o, 0.2s);
+    }
+
+    &:checked {
+      --b: var(--active);
+      --bc: var(--active);
+      border-color: #275efe;
+      --d-o: 0.3s;
+      --d-t: 0.6s;
+      --d-t-e: cubic-bezier(0.2, 0.85, 0.32, 1.2);
+    }
+
+    &:disabled {
+      --b: var(--disabled);
+      cursor: not-allowed;
+      opacity: 0.9;
+      &:checked {
+        --b: var(--disabled-inner);
+        --bc: var(--border);
+      }
+      & + label {
+        cursor: not-allowed;
+      }
+    }
+
+    &:hover {
+      &:not(:checked) {
+        &:not(:disabled) {
+          --bc: var(--border-hover);
+        }
+      }
+    }
+
+    &:focus {
+      box-shadow: 0 0 0 var(--focus);
+    }
+    &:not(.switch) {
+      width: 21px;
+      &:after {
+        opacity: var(--o, 0);
+      }
+      &:checked {
+        --o: 1;
+      }
+    }
+
+    & + label {
+      // font-size: 14px;
+      // line-height: 21px;
+      display: inline-block;
+      vertical-align: top;
+      cursor: pointer;
+      margin-left: 4px;
+    }
+
+    border-radius: 50%;
+    &:after {
+      width: 19px;
+      height: 19px;
+      border-radius: 50%;
+      background: var(--active-inner);
+      opacity: 0;
+      transform: scale(var(--s, 0.7));
+    }
+    &:checked {
+      --s: 0.5;
+    }
+  }
+}

--- a/src/style/reset.scss
+++ b/src/style/reset.scss
@@ -1,4 +1,5 @@
 @import "./constants";
+@import "./radio";
 
 /* https://dev.to/hankchizljaw/a-modern-css-reset-6p3 */
 /* Box sizing rules */


### PR DESCRIPTION
These are _placeholder_ styles! We will not be using blue for the buttons. Just want to get the code in there and style/clean up as a follow-up.

<img width="1680" alt="Radios" src="https://user-images.githubusercontent.com/32101487/88467752-6c98c400-cea8-11ea-95d5-2dc8d7e2cba8.png">
